### PR TITLE
fix: update event links and redirect logic for public events

### DIFF
--- a/frontend/src/components/dashboard/events/EventCard.tsx
+++ b/frontend/src/components/dashboard/events/EventCard.tsx
@@ -59,7 +59,7 @@ export function EventCard({ eventItem }: { eventItem: VmsEvent }) {
           </span>
         </div>
         <Link
-          to={eventItem.status === 'public' ? `/event/${eventItem.id}` : `/dashboard/event/${eventItem.id}`}
+          to={`/dashboard/event/${eventItem.id}`}
           className="mt-4 inline-flex w-full items-center justify-center rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 shadow-sm transition hover:border-cyan-300 hover:bg-cyan-50"
         >
           عرض التفاصيل

--- a/frontend/src/pages/PublicEventPage.tsx
+++ b/frontend/src/pages/PublicEventPage.tsx
@@ -1,7 +1,16 @@
+import { Navigate, useParams } from 'react-router-dom'
 import { PublicEventShell } from '../components/events/PublicEventShell'
+import { getStoredUser } from '../utils/auth'
 import { DashboardEventDetailsPage } from './dashboard/DashboardEventDetailsPage'
 
 export function PublicEventPage() {
+  const { eventID } = useParams()
+  const user = getStoredUser()
+
+  if (user && eventID) {
+    return <Navigate to={`/dashboard/event/${eventID}`} replace />
+  }
+
   return (
     <PublicEventShell>
       <DashboardEventDetailsPage />


### PR DESCRIPTION
- Simplified the link structure in EventCard to always point to the dashboard event page.
- Implemented a redirect in PublicEventPage to navigate users to the dashboard event page if they are logged in and access a public event.