### PR TITLE
refactor: update SQL migrations to remove IF NOT EXISTS clause for co…

### DIFF
--- a/database/vms/migrations/2026_06_19_1_add_display_attendee_numbers.sql
+++ b/database/vms/migrations/2026_06_19_1_add_display_attendee_numbers.sql
@@ -1,3 +1,3 @@
 -- Upgrade for databases that applied main.sql before display_attendee_numbers existed.
--- Fresh installs receive this column from main.sql; IF NOT EXISTS makes this a no-op there.
-ALTER TABLE events ADD COLUMN IF NOT EXISTS display_attendee_numbers INTEGER NOT NULL DEFAULT 1;
+-- Fresh installs that bootstrap from current main.sql should mark this migration as applied instead of running it.
+ALTER TABLE events ADD COLUMN display_attendee_numbers INTEGER NOT NULL DEFAULT 1;

--- a/database/vms/migrations/2026_06_19_2_add_cancellation_deadline_hours.sql
+++ b/database/vms/migrations/2026_06_19_2_add_cancellation_deadline_hours.sql
@@ -1,1 +1,1 @@
-ALTER TABLE events ADD COLUMN IF NOT EXISTS cancellation_deadline_hours INTEGER NOT NULL DEFAULT 48;
+ALTER TABLE events ADD COLUMN cancellation_deadline_hours INTEGER NOT NULL DEFAULT 48;


### PR DESCRIPTION
…lumn additions

- Revised migration scripts for `display_attendee_numbers` and `cancellation_deadline_hours` columns to remove the IF NOT EXISTS clause, ensuring fresh installs correctly apply the migrations without skipping them.